### PR TITLE
ETL: Add support to second-stage tender

### DIFF
--- a/migrations/ocds/001-paraguay.sql
+++ b/migrations/ocds/001-paraguay.sql
@@ -233,3 +233,4 @@ WHERE NOT parties.roles ? 'buyer'::text
   AND parties.party_id ~~ 'PY-RUC-%'::text );
 
 alter table ocds.procurement add column if not exists tender_procurementmethod text;
+alter table ocds.procurement add column if not exists second_stage boolean;

--- a/migrations/ocds/001-paraguay.sql
+++ b/migrations/ocds/001-paraguay.sql
@@ -159,6 +159,62 @@ create table if not exists ocds.award_items
     data_id                    bigint
 );
 
+create table if not exists ocds.second_stage_invitations
+(
+    ocid                                  text,
+    invitations_id                        text,
+    id                                    bigserial not null,
+    title                                 text,
+    status                                text,
+    award_criteria                        text,
+    award_criteriadetails                 text,
+    submission_methoddetails              text,
+    status_details                        text,
+    numberofnotifiedsuppliers             numeric,
+    mainprocurementcategorydetails        text,
+    date_published                        timestamp,
+    amount                                numeric,
+    currency                              text,
+    submission_period_start_date          timestamp,
+    submission_period_end_date            timestamp,
+    award_period_start_date               timestamp,
+    award_period_end_date                 timestamp,
+    numberofenquiries                     numeric,
+    procurementmethod                     text,
+    procurementmethoddetails              text,
+    numberofsubmitters                    numeric,
+    framework_agreement                   boolean,
+    electronic_auction                    boolean,
+    buyer_id                              text,
+    buyer_name                            text,
+    bidopening_date                       timestamp,
+    clarification_meetings_date           timestamp,
+    characteristics                       text,
+    documents                             jsonb,
+    data_id                               bigint,
+    url                                   text,
+    constraint second_stage_invitations_pk PRIMARY KEY (id)
+);
+
+create table if not exists ocds.second_stage_invitations_items
+(
+    ocid                                 text,
+    invitations_id                       text,
+    id                                   bigserial not null,
+    item_id                              text,
+    description                          text,
+    classification_id                    text,
+    classification_description           text,
+    quantity                             numeric,
+    unit_name                            text,
+    unit_price                           numeric,
+    unit_price_currency                  text,
+    attributes                           jsonb,
+    lot                                  text,
+    data_id                              bigint,
+    constraint second_stage_invitations_items_pk PRIMARY KEY (id)
+);
+
 CREATE MATERIALIZED VIEW IF NOT EXISTS ocds.unique_suppliers AS
 (
 SELECT DISTINCT parties.name                                  AS name,

--- a/transform/ocds/01-transform.sql
+++ b/transform/ocds/01-transform.sql
@@ -4,7 +4,7 @@ INSERT INTO ocds.procurement (release_date, ocid, data_id, tender_id, characteri
                                   tender_bidopening_date, tender_awardcriteria_details, tender_status, tender_status_details,
                                   tender_title, tender_mainprocurementcategorydetails, tender_numberoftenderers, analyzed, number_of_awards,
                                   framework_agreement, electronic_auction, budget, documents, tender_numberofenquiries, url,
-                              tender_procurementmethod)   (
+                              tender_procurementmethod, second_stage)   (
     SELECT
     distinct
     (data->>'date')::timestamp as release_date,
@@ -43,7 +43,8 @@ INSERT INTO ocds.procurement (release_date, ocid, data_id, tender_id, characteri
          then 'https://contrataciones.gov.py/sin-difusion-convocatoria/'|| (data->'tender'->>'id') || '.html'
          else 'https://contrataciones.gov.py/licitaciones/convocatoria/'|| (data->'tender'->>'id') || '.html'
        end                                           as url,
-                        data->'tender'->>'procurementMethod' as procurement_method
+                        data->'tender'->>'procurementMethod' as procurement_method,
+                        case when data->'secondStage' is not null then TRUE else FALSE end as second_stage
            FROM (
     SELECT
         data.id as data_id,

--- a/transform/ocds/03-delete-duplicated.sql
+++ b/transform/ocds/03-delete-duplicated.sql
@@ -24,6 +24,14 @@ delete from ocds.procurement where data_id in (
 select a.data_id from ocds.procurement a
 join ocds.procurement b on a.ocid = b.ocid and a.id < b.id);
 
+delete from ocds.second_stage_invitations where data_id in (
+select a.data_id from ocds.procurement a
+join ocds.procurement b on a.ocid = b.ocid and a.id < b.id);
+
+delete from ocds.second_stage_invitations_items where data_id in (
+select a.data_id from ocds.procurement a
+join ocds.procurement b on a.ocid = b.ocid and a.id < b.id);
+
 refresh materialized view ocds.unique_suppliers;
 
 create table if not exists ocds.precios_pre_pandemia as (

--- a/transform/ocds/03-delete-duplicated.sql
+++ b/transform/ocds/03-delete-duplicated.sql
@@ -20,15 +20,15 @@ delete from ocds.parties where data_id in (
 select a.data_id from ocds.procurement a
 join ocds.procurement b on a.ocid = b.ocid and a.id < b.id);
 
-delete from ocds.procurement where data_id in (
-select a.data_id from ocds.procurement a
-join ocds.procurement b on a.ocid = b.ocid and a.id < b.id);
-
 delete from ocds.second_stage_invitations where data_id in (
 select a.data_id from ocds.procurement a
 join ocds.procurement b on a.ocid = b.ocid and a.id < b.id);
 
 delete from ocds.second_stage_invitations_items where data_id in (
+select a.data_id from ocds.procurement a
+join ocds.procurement b on a.ocid = b.ocid and a.id < b.id);
+
+delete from ocds.procurement where data_id in (
 select a.data_id from ocds.procurement a
 join ocds.procurement b on a.ocid = b.ocid and a.id < b.id);
 


### PR DESCRIPTION
The second stage data are available on these tables:
* ocds.second_stage_invitations
* ocds.second_stage_invitations_items